### PR TITLE
fix:针对思考类模型的返回，总结标题仅截取</think>之后的内容

### DIFF
--- a/src/renderer/src/providers/OpenAIProvider.ts
+++ b/src/renderer/src/providers/OpenAIProvider.ts
@@ -341,7 +341,11 @@ export default class OpenAIProvider extends BaseProvider {
       max_tokens: 1000
     })
 
-    return removeSpecialCharacters(response.choices[0].message?.content?.substring(0, 50) || '')
+    // 针对思考类模型的返回，总结仅截取</think>之后的内容
+    let content = response.choices[0].message?.content || ''
+    content = content.replace(/^<think>(.*?)<\/think>/s, '')
+    
+    return removeSpecialCharacters(content.substring(0, 50))
   }
 
   public async generateText({ prompt, content }: { prompt: string; content: string }): Promise<string> {


### PR DESCRIPTION
fix #1172

# 问题描述

使用r1思考类模型作为话题命名模型时，自动命名会返回前面的think部分

![image](https://github.com/user-attachments/assets/8e31fc9f-f6a1-4f2c-a003-4fdd511c60aa)

# 修改内容

将总结标题处的代码，仅截取```<think>...</think>```之后的内容

# 本地测试

- [ ✔]  r1思考类模型会截取后面的正文
- [ ✔] 其他类模型还是按照之前的方式不影响